### PR TITLE
Fix the issue where SwiftUI TextField does not work.

### DIFF
--- a/ios/ExpoPasteInputView.swift
+++ b/ios/ExpoPasteInputView.swift
@@ -77,6 +77,13 @@ class ExpoPasteInputView: ExpoView {
     super.didAddSubview(subview)
     startMonitoring()
   }
+
+  override func layoutSubviews() {
+    super.layoutSubviews()
+    if !isMonitoring {
+      startMonitoring()
+    }
+  }
   
   private func startMonitoring() {
     guard !isMonitoring else { return }
@@ -302,9 +309,7 @@ class ExpoPasteInputView: ExpoView {
   }
   
   private func findTextInputInView(_ view: UIView) -> UIView? {
-    let className = String(describing: type(of: view))
-    if className.contains("RCTUITextField") || className.contains("RCTUITextView") ||
-       className.contains("UITextField") || className.contains("UITextView") {
+    if view is TextInputEnhanceable {
       return view
     }
     


### PR DESCRIPTION
## example

```typescript
import { PasteEventPayload, TextInputWrapper } from "@/modules/expo-text-input-wrapper";
import { Host } from "@expo/ui/swift-ui";
import { frame } from "@expo/ui/swift-ui/modifiers";

<TextInputWrapper onPaste={onPaste}>
  <Host matchContents={{ vertical: true }} style={{ width: "100%" }}>
    <TextField
      modifiers={[
        frame({ maxWidth: Infinity, alignment: "leading" }),
      ]}
      onChangeText={setValue}
      placeholder="What's happening?"
      multiline
      numberOfLines={8}
      autocorrection={false}
    />
  </Host>
</TextInputWrapper>
```