### PR TITLE
fix(ios): don't screenshot text attachments without a real image payload

### DIFF
--- a/ios/ExpoPasteInputView.swift
+++ b/ios/ExpoPasteInputView.swift
@@ -511,14 +511,17 @@ class ExpoPasteInputView: ExpoView {
     var attachmentRanges: [NSRange] = []
     var mediaPayloads: [MediaPayload] = []
 
+    // Only track ranges for attachments we successfully extract a real payload
+    // from. Attachments without a payload (e.g. iOS dictation placeholders)
+    // are left alone — sanitizing them would delete characters the system
+    // manages itself, and emitting "unsupported" would raise a spurious error.
     attributedText.enumerateAttribute(.attachment, in: NSRange(location: 0, length: attributedText.length), options: []) { value, range, _ in
       guard let attachment = value as? NSTextAttachment else {
         return
       }
 
-      attachmentRanges.append(range)
-
       if let payload = self.extractMediaPayload(from: attachment, textView: textView, range: range) {
+        attachmentRanges.append(range)
         mediaPayloads.append(payload)
       }
     }
@@ -529,9 +532,8 @@ class ExpoPasteInputView: ExpoView {
           return
         }
 
-        attachmentRanges.append(range)
-
         if let payload = self.extractMediaPayload(from: adaptiveGlyph) {
+          attachmentRanges.append(range)
           mediaPayloads.append(payload)
         }
       }
@@ -539,16 +541,11 @@ class ExpoPasteInputView: ExpoView {
 
     attachmentRanges = uniqueRanges(attachmentRanges)
 
-    guard !attachmentRanges.isEmpty else {
+    guard !mediaPayloads.isEmpty else {
       return
     }
 
     sanitizeAttachments(in: textView, ranges: attachmentRanges)
-
-    guard !mediaPayloads.isEmpty else {
-      handleUnsupportedPaste()
-      return
-    }
 
     emitImagesAsync(for: mediaPayloads)
   }
@@ -651,6 +648,11 @@ class ExpoPasteInputView: ExpoView {
   }
 
   private func extractMediaPayload(from attachment: NSTextAttachment, textView: UITextView, range: NSRange) -> MediaPayload? {
+    // Only accept attachments that carry real image payloads. We intentionally
+    // do not fall back to `image(forBounds:)` or rendering the text view's
+    // hierarchy, because system-inserted attachments (e.g. the iOS dictation
+    // placeholder) draw themselves via those paths and would cause us to
+    // emit a screenshot of the composer as a "pasted image".
     if let fileWrapperData = attachment.fileWrapper?.regularFileContents,
        let payload = extractMediaPayload(fromData: fileWrapperData) {
       return payload
@@ -665,20 +667,6 @@ class ExpoPasteInputView: ExpoView {
        image.size.width > 0,
        image.size.height > 0 {
       return .image(image)
-    }
-
-    let attachmentBounds = attachment.bounds.size.width > 0 && attachment.bounds.size.height > 0
-      ? attachment.bounds
-      : CGRect(origin: .zero, size: CGSize(width: 128, height: 128))
-
-    if let image = attachment.image(forBounds: attachmentBounds, textContainer: textView.textContainer, characterIndex: range.location),
-       image.size.width > 0,
-       image.size.height > 0 {
-      return .image(image)
-    }
-
-    if let renderedImage = renderTextAttachment(in: textView, range: range) {
-      return .image(renderedImage)
     }
 
     return nil
@@ -699,47 +687,6 @@ class ExpoPasteInputView: ExpoView {
     }
 
     return .imageData(data)
-  }
-
-  private func renderTextAttachment(in textView: UITextView, range: NSRange) -> UIImage? {
-    let glyphRange = textView.layoutManager.glyphRange(forCharacterRange: range, actualCharacterRange: nil)
-    var rect = textView.layoutManager.boundingRect(forGlyphRange: glyphRange, in: textView.textContainer)
-
-    rect.origin.x += textView.textContainerInset.left - textView.contentOffset.x
-    rect.origin.y += textView.textContainerInset.top - textView.contentOffset.y
-    rect = rect.integral
-
-    guard rect.width > 1, rect.height > 1 else {
-      return nil
-    }
-
-    let format = UIGraphicsImageRendererFormat.default()
-    format.scale = textView.window?.screen.scale ?? UIScreen.main.scale
-    format.opaque = false
-
-    let image = UIGraphicsImageRenderer(size: rect.size, format: format).image { _ in
-      let drawRect = CGRect(
-        origin: CGPoint(x: -rect.origin.x, y: -rect.origin.y),
-        size: textView.bounds.size
-      )
-
-      if textView.window != nil {
-        textView.drawHierarchy(in: drawRect, afterScreenUpdates: false)
-      } else {
-        guard let context = UIGraphicsGetCurrentContext() else {
-          return
-        }
-
-        context.translateBy(x: -rect.origin.x, y: -rect.origin.y)
-        textView.layer.render(in: context)
-      }
-    }
-
-    guard image.size.width > 0, image.size.height > 0 else {
-      return nil
-    }
-
-    return image
   }
 
   @available(iOS 18.0, *)


### PR DESCRIPTION
## Summary

Fixes a bug where iOS Dictation causes `onPaste` to fire at the end of every dictation session with `type: 'images'` and a zoomed-in screenshot of the wrapped text view. Should fix https://github.com/arunabhverma/expo-paste-input/issues/5

## Repro

1. Build the example app (or any app using `TextInputWrapper`) on a real iOS device.
2. Focus the text input, tap the mic / start Dictation, say a few words, end dictation.
3. `onPaste` fires with `type: 'images'` and a URI pointing to a rasterized image of whatever pixels sat under the dictation indicator.

Happens regardless of whether the text view is empty or already has content.

## Cause

`handleTextViewDidChange` observes `UITextView.textDidChangeNotification` and enumerates every `.attachment` attribute in the `attributedText`. iOS Dictation inserts its own `NSTextAttachment` (the dictation indicator / shimmer). That attachment carries no real payload, so `extractMediaPayload` falls through to:

1. `attachment.image(forBounds:textContainer:characterIndex:)` — which can return whatever the system attachment chooses to draw.
2. `renderTextAttachment` — which rasterizes the text view's own hierarchy at the attachment's glyph rect via `drawHierarchy`.

The result is a "pasted image" that is actually a screenshot of the composer.

Separately, `handleTextViewDidChange` also:
- calls `sanitizeAttachments` on every attachment range, deleting characters iOS is managing itself, and
- calls `handleUnsupportedPaste` when no payload could be extracted, raising a spurious `type: 'unsupported'` event.

## Fix

- **`extractMediaPayload(from: NSTextAttachment, ...)`** only accepts attachments carrying a real payload (`fileWrapper?.regularFileContents`, `contents`, or `image`). The `image(forBounds:)` and `renderTextAttachment` fallbacks are removed — real image pastes arrive via the swizzled `paste(_:)` path, and real Genmoji arrive via `insertAdaptiveImageGlyph:replacementRange:`, so neither fallback had a legitimate source I could identify.
- **`handleTextViewDidChange`** only tracks an attachment's range if `extractMediaPayload` returned a payload. If no payloads are produced, it returns early instead of sanitizing ranges and firing `handleUnsupportedPaste()`. Unknown system attachments (dictation placeholder, any future system-managed attachments) are left untouched.
- Removes `renderTextAttachment` as dead code.

## Test plan

- [x] Dictation into a wrapped TextInput no longer emits a `type: 'images'` event. (Verified on iOS 18 in Bluesky's composer.)
- [ ] Pasting an image from the clipboard still works — unchanged by this PR (goes through `paste()` → `processPasteboardContent()`), but worth confirming.
- [ ] Pasting a GIF still works — same as above.
- [ ] Pasting Genmoji (iOS 18+) still works — also unchanged (goes through the `insertAdaptiveImageGlyph` swizzle).

Happy to add a test case or adjust if you'd like a narrower fix (e.g. gating the fallbacks behind a check for `UIDictationPlaceholder` specifically) — I went with the wider change because I couldn't find a legitimate source for either fallback path, but your read on the intended behavior is better than mine.